### PR TITLE
Clarified PM Errors

### DIFF
--- a/samples/tmo_shell/src/tmo_ble_demo.c
+++ b/samples/tmo_shell/src/tmo_ble_demo.c
@@ -214,8 +214,8 @@ static ssize_t battery_power_source_get(struct bt_conn *conn,
                                 const struct bt_gatt_attr *attr, void *buf,
                                 uint16_t len, uint16_t offset)
 {
-        uint8_t power_source;
-        if (battery_is_charging == true) {
+	uint8_t power_source;
+	if (battery_is_charging == true) {
 		power_source = ON_CHARGER_POWER;
 	} else {
 		power_source = ON_BATTERY_POWER;

--- a/samples/tmo_shell/src/tmo_pm.c
+++ b/samples/tmo_shell/src/tmo_pm.c
@@ -22,7 +22,9 @@ int cmd_pmresume(const struct shell *shell, int argc, char** argv)
 	}
 
 	ret = pm_device_action_run(dev, PM_DEVICE_ACTION_RESUME);
-	if (ret) {
+	if (ret == -ENOTSUP) {
+		shell_warn(shell, "Device %s does not support action PM_DEVICE_ACTION_RESUME; Command ignored", argv[1]);
+	} else if (ret) {
 		shell_error(shell, "Failed to execute power management action, err=%d", ret);
 	}
 	return ret;
@@ -40,7 +42,9 @@ int cmd_pmsuspend(const struct shell *shell, int argc, char** argv)
 	}
 
 	ret = pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
-	if (ret) {
+	if (ret == -ENOTSUP) {
+		shell_warn(shell, "Device %s does not support action PM_DEVICE_ACTION_SUSPEND; Command ignored", argv[1]);
+	} else if (ret) {
 		shell_error(shell, "Failed to execute power management action, err=%d", ret);
 	}
 	return ret;
@@ -58,7 +62,9 @@ int cmd_pmoff(const struct shell *shell, int argc, char** argv)
 	}
 
 	ret = pm_device_action_run(dev, PM_DEVICE_ACTION_TURN_OFF);
-	if (ret) {
+	if (ret == -ENOTSUP) {
+		shell_warn(shell, "Device %s does not support action PM_DEVICE_ACTION_TURN_OFF; Command ignored", argv[1]);
+	} else if (ret) {
 		shell_error(shell, "Failed to execute power management action, err=%d", ret);
 	}
 	return ret;
@@ -76,7 +82,9 @@ int cmd_pmon(const struct shell *shell, int argc, char** argv)
 	}
 
 	ret = pm_device_action_run(dev, PM_DEVICE_ACTION_TURN_ON);
-	if (ret) {
+	if (ret == -ENOTSUP) {
+		shell_warn(shell, "Device %s does not support action PM_DEVICE_ACTION_TURN_ON; Command ignored", argv[1]);
+	} else if (ret) {
 		shell_error(shell, "Failed to execute power management action, err=%d", ret);
 	}
 


### PR DESCRIPTION
Made calling PM actions not supported by devices print more informative error messages.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>