### PR TITLE
Fixed cert overwrite on modem

### DIFF
--- a/samples/tmo_shell/src/tmo_shell.c
+++ b/samples/tmo_shell/src/tmo_shell.c
@@ -2178,7 +2178,7 @@ int cmd_tmo_cert_modem_load(const struct shell* shell, int argc, char **argv)
 		return EIO;
 	}
 
-	if (fcntl(sock, CHECK_CERT, name)) {
+	if (fcntl(sock, CHECK_CERT, name) == 0) {
 		if (!force) {
 			shell_error(shell, "Cert already loaded!");
 			zsock_close(sock);


### PR DESCRIPTION
Fixed reversed logic in certs modem_load to enable overwrite.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>