### PR TITLE
Fixed AS6212 Devicetree binding

### DIFF
--- a/boards/arm/tmo_dev_edge/tmo_dev_edge.dts
+++ b/boards/arm/tmo_dev_edge/tmo_dev_edge.dts
@@ -258,8 +258,7 @@
 
     /*AMS Temperature Sensor */
     as6212: as6212@48 {
-        compatible = "ams,as6212", "ti,tmp108";
-        variant-as621x;
+        compatible = "ams,as6212";
         reg = <0x48 0x4>;
         status = "okay";
         alert-gpios = <&gpiof 14 GPIO_ACTIVE_LOW>;


### PR DESCRIPTION
Fixed AS6212 temperature sensor binding to match with the expectations of the upstream driver.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>