### PR TITLE
Fixed tmo_modem.c includes

### DIFF
--- a/samples/tmo_shell/src/tmo_modem.c
+++ b/samples/tmo_shell/src/tmo_modem.c
@@ -1,6 +1,6 @@
 #include <errno.h>
 #include <fcntl.h>
-#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <zephyr/drivers/modem/murata-1sc.h>
 #include <zephyr/net/socket.h>
 


### PR DESCRIPTION
Removed reference to the deprecated zephyr.h header file

Signed-off-by: Jared Baumann <Jared.Baumann8@t-mobile.com>