### PR TITLE
Fixed flipped logic for murata checks

### DIFF
--- a/samples/tmo_shell/src/tmo_modem.c
+++ b/samples/tmo_shell/src/tmo_modem.c
@@ -88,7 +88,7 @@ static int tmo_modem_get_sock(int idx) {
 	if (iface == NULL) {
 		return -EINVAL;
 	}
-	if (strstr(iface->if_dev->dev->name, "murata")) {
+	if (!strstr(iface->if_dev->dev->name, "murata")) {
 		return -EINVAL;
 	}
 	sd = zsock_socket_ext(AF_INET, SOCK_STREAM, IPPROTO_TCP, iface);

--- a/samples/tmo_shell/src/tmo_shell.c
+++ b/samples/tmo_shell/src/tmo_shell.c
@@ -1230,7 +1230,7 @@ int cmd_modem(const struct shell *shell, size_t argc, char **argv)
 		shell_error(shell, "Interface %d not found", idx);
 		return -EINVAL;
 	}
-	if (strstr(iface->if_dev->dev->name, "murata")) {
+	if (!strstr(iface->if_dev->dev->name, "murata")) {
 		shell_error(shell, "dev - %s Not Supported; only Murata 1SC is supported", iface->if_dev->dev->name);
 		return -EINVAL;
 	}

--- a/samples/tmo_shell/src/tmo_web_demo.c
+++ b/samples/tmo_shell/src/tmo_web_demo.c
@@ -115,7 +115,7 @@ int get_cell_strength(int *val)
 	if (iface == NULL) {
 		return -EINVAL;
 	}
-	if (strstr(iface->if_dev->dev->name, "murata")) {
+	if (!strstr(iface->if_dev->dev->name, "murata")) {
 		return -EINVAL;
 	}
 	int sd = zsock_socket_ext(AF_INET, SOCK_STREAM, IPPROTO_TCP, iface);


### PR DESCRIPTION
Properly checks for murata interface for modem command as well as others

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>