### PR TITLE
Fix warnings on bootloader build

### DIFF
--- a/samples/tmo_shell/boards/tmo_dev_edge_mcuboot.overlay
+++ b/samples/tmo_shell/boards/tmo_dev_edge_mcuboot.overlay
@@ -13,17 +13,15 @@ chosen {
 &flash0 {
 
     partitions {
-	boot_partition: partition@0 {
-	    label = "mcuboot";
-	    reg = <0x00000000 DT_SIZE_K(64)>;
-	};
-	slot0_partition: partition@10000 {
-	    label = "image-0";
-	    reg = <0x00010000 DT_SIZE_K(448)>;
-	};
-	slot1_partition: partition@80000 {
-	    label = "image-1";
-	    reg = <0x00080000 DT_SIZE_K(448)>;
-	};
+		compatible = "fixed-partitions";
+		boot_partition: partition@0 {
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+		slot0_partition: partition@10000 {
+			reg = <0x00010000 DT_SIZE_K(448)>;
+		};
+		slot1_partition: partition@80000 {
+			reg = <0x00080000 DT_SIZE_K(448)>;
+		};
     };
 };

--- a/samples/tmo_shell/overlay-bl.conf
+++ b/samples/tmo_shell/overlay-bl.conf
@@ -19,13 +19,8 @@ CONFIG_INIT_ARCH_HW_AT_BOOT=y
 # Relay exceptions and interrupts based on a vector table pointer that is set by the chain-loadable application.
 CONFIG_SW_VECTOR_RELAY=y
 
-# Instruct the boot sequence to set the vector table pointer in SRAM so that the bootloader can forward
-# the exceptions and interrupts to the chain-loadable image’s software vector table.
-CONFIG_SW_VECTOR_RELAY_CLIENT=y
-
 # Zephyr will relocate .text, data and .bss sections from the specified files and
 # place it in SRAM.
 CONFIG_BOOT_DIRECT_XIP=y
-CONFIG_BOOTLOADER_MCUBOOT=y
 
 CONFIG_SPI=y

--- a/samples/tmo_shell/overlay-slot.conf
+++ b/samples/tmo_shell/overlay-slot.conf
@@ -17,7 +17,3 @@ CONFIG_INIT_ARCH_HW_AT_BOOT=y
 
 # Relay exceptions and interrupts based on a vector table pointer that is set by the chain-loadable application.
 CONFIG_SW_VECTOR_RELAY=y
-
-# Instruct the boot sequence to set the vector table pointer in SRAM so that the bootloader
-# can forward the exceptions and interrupts to the chain-loadable image’s software vector table.
-CONFIG_SW_VECTOR_RELAY_CLIENT=y


### PR DESCRIPTION
Fixed configs to eliminate bootloader CMake warnings.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>