### PR TITLE
Added WiFi MAC read command

### DIFF
--- a/samples/tmo_shell/src/tmo_shell.c
+++ b/samples/tmo_shell/src/tmo_shell.c
@@ -1513,6 +1513,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(tmo_wifi_commands,
 			cmd_wifi_connect),
 		SHELL_CMD(disconnect, NULL, "\"<iface>\"",
 			cmd_wifi_disconnect),
+		SHELL_CMD(mac, NULL, "\"<iface>\"",
+			cmd_wifi_mac),
 		SHELL_CMD(scan, NULL, "\"<iface>\"", cmd_wifi_scan),
 		SHELL_CMD(status, NULL, "\"<iface>\"", cmd_wifi_status),
 		SHELL_SUBCMD_SET_END

--- a/samples/tmo_shell/src/tmo_shell.h
+++ b/samples/tmo_shell/src/tmo_shell.h
@@ -67,6 +67,7 @@ int cmd_wifi_connect(const struct shell *shell, size_t argc, char *argv[]);
 int cmd_wifi_disconnect(const struct shell *shell, size_t argc, char *argv[]);
 int cmd_wifi_scan(const struct shell *shell, size_t argc, char *argv[]);
 int cmd_wifi_status(const struct shell *shell, size_t argc, char *argv[]);
+int cmd_wifi_mac(const struct shell *shell, size_t argc, char *argv[]);
 
 int toggle_keyboard(const struct shell *shell, size_t argc, char *argv[]);
 int toggle_confirm(const struct shell *shell, size_t argc, char *argv[]);


### PR DESCRIPTION
Added command to read the MAC address from the RS9116 WiFi chip.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>