### PR TITLE
Temporarily disabled standby command

### DIFF
--- a/samples/tmo_shell/src/tmo_shell.c
+++ b/samples/tmo_shell/src/tmo_shell.c
@@ -2336,7 +2336,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_sys_pm,
 	SHELL_CMD(fulloff, NULL, "Put system into the off state (Without RTCC)", cmd_pmsysfulloff),
 	SHELL_CMD(idle, NULL, "Put system into idle state", cmd_pmsysidle),
 	SHELL_CMD(off, NULL, "Put system into the off state (Retaining RTCC)", cmd_pmsysoff),
-	SHELL_CMD(standby, NULL, "Put system into the standby state", cmd_pmsysstandby),
+	/* Disabled until fixed in SOC code*/
+	// SHELL_CMD(standby, NULL, "Put system into the standby state", cmd_pmsysstandby),
 	SHELL_CMD(suspend, NULL, "Put system into the suspend state", cmd_pmsyssuspend),
 	SHELL_SUBCMD_SET_END
 	);


### PR DESCRIPTION
Disabled the sys_pm standby command awaiting power control changes from upstream.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>