### PR TITLE
Fixed download resume logic on modem

### DIFF
--- a/samples/tmo_shell/src/tmo_http_request.c
+++ b/samples/tmo_shell/src/tmo_http_request.c
@@ -432,7 +432,7 @@ int tmo_http_download(int devid, char url[], char filename[])
 		if (ret == -1) {
 			zsock_close(sock);
 			sock = create_http_socket(tls, host, res, iface);
-			int profile = 255;
+			profile = 255;
 			zsock_setsockopt(sock, SOL_TLS, TLS_MURATA_USE_PROFILE, &profile, sizeof(profile));
 			ret = zsock_connect(sock, res->ai_addr, res->ai_addrlen);
 			user_trust = true;


### PR DESCRIPTION
Fixed issue where download resume would fail on the murata modem.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>