### PR TITLE
Fix tmo shell build in HEAD

### DIFF
--- a/samples/tmo_shell/src/tmo_ping.c
+++ b/samples/tmo_shell/src/tmo_ping.c
@@ -6,6 +6,8 @@
 
 #include <zephyr/kernel.h>
 #include <zephyr/shell/shell.h>
+#include <zephyr/posix/unistd.h>
+#include <getopt.h>
 #include <zephyr/net/ping.h>
 #include <zephyr/net/socket.h>
 #include "tmo_shell.h"

--- a/samples/tmo_shell/src/tmo_shell.c
+++ b/samples/tmo_shell/src/tmo_shell.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(tmo_shell, LOG_LEVEL_INF);
 #include <stdio.h>
 #include <zephyr/fs/fs.h>
 #include <zephyr/kernel.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/net/socket.h>
 #include <zephyr/shell/shell.h>
 #include <zephyr/shell/shell_uart.h>


### PR DESCRIPTION
Fix includes for tmo-shell so that we can build with HEAD

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>