### PR TITLE
Fixed old FCNTL paths to eliminate warnings

### DIFF
--- a/samples/tmo_shell/src/tmo_ble_demo.c
+++ b/samples/tmo_shell/src/tmo_ble_demo.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #include <errno.h>
 #include <zephyr/kernel.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/random/rand32.h>

--- a/samples/tmo_shell/src/tmo_http_request.c
+++ b/samples/tmo_shell/src/tmo_http_request.c
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(tmo_http_request, LOG_LEVEL_DBG);
 
 #if CONFIG_MODEM
 #include <zephyr/drivers/modem/murata-1sc.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #endif
 
 #define MAX_RECV_BUF_LEN 512

--- a/samples/tmo_shell/src/tmo_modem.c
+++ b/samples/tmo_shell/src/tmo_modem.c
@@ -1,5 +1,5 @@
 #include <errno.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/modem/murata-1sc.h>
 #include <zephyr/net/socket.h>

--- a/samples/tmo_shell/src/tmo_web_demo.c
+++ b/samples/tmo_shell/src/tmo_web_demo.c
@@ -8,7 +8,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <zephyr/kernel.h>
-#include <fcntl.h>
+#include <zephyr/posix/fcntl.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/net/net_ip.h>
 #include <zephyr/net/socket.h>


### PR DESCRIPTION
Removed includes referencing deprecated fnctl location, replacing with new path.

Signed-off-by: Jared Baumann <jared.baumann8@t-mobile.com>