### PR TITLE
Improve tmo test mfg all command

### DIFF
--- a/samples/tmo_shell/src/misc_test.c
+++ b/samples/tmo_shell/src/misc_test.c
@@ -35,69 +35,73 @@ int misc_test()
 {
 	int ret = 0, rc = 0;
 
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "device list")) != 0) {
+		rc |= ret;
+		printf("device list - shell command failed %d\n", ret);
+	} else {
+		printf("device list - shell command was successful\n");
+	}
+
 #if DT_NODE_EXISTS(DT_NODELABEL(as6212))
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "sensor get " TEMP_0)) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "sensor get " TEMP_0)) != 0) {
 		rc |= ret;
 		printf("sensor get " TEMP_0  " - as6212 temp sensor - shell command failed %d \n", ret);
 	} else {
 		printf("sensor get " TEMP_0  " - as6212 temp sensor - shell command was successful\n");
 	}
 #endif
+
 #if DT_NODE_EXISTS(DT_NODELABEL(bq24250))
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "i2c read_byte " I2C_1 " 0x6a 0x3")) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "i2c read_byte " I2C_1 " 0x6a 0x3")) != 0) {
 		rc |= ret;
 		printf("i2c read_byte " I2C_1 " 0x6a 0x3 - BQ24250 voltage regulator- shell command failed %d \n", ret);
 	} else {
 		printf("i2c read_byte " I2C_1 " 0x6a 0x3 - BQ24250 voltage regulator- shell command was successful\n");
 	}
 #else
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "i2c read " I2C_1 " 25 10")) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "i2c read " I2C_1 " 25 10")) != 0) {
 		rc |= ret;
 		printf("i2c read " I2C_1 " 25 10 - ACT81460 PMIC - shell command failed %d \n", ret);
 	} else {
 		printf("i2c read " I2C_1 " 25 10 - ACT81460 PMIC - shell command was successful\n");
 	}
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "i2c write_byte " I2C_1 " 25 47 98")) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "i2c write_byte " I2C_1 " 25 47 98")) != 0) {
 		rc |= ret;
 		printf("i2c write_byte " I2C_1 " 25 47 98 - ACT81460 PMIC turn on GNSS - shell command failed %d \n", ret);
 	} else {
 		printf("i2c write_byte " I2C_1 " 25 47 98 - ACT81460 PMIC turn on GNSS - shell command was successful\n");
 	}
 #endif
+
 #if DT_NODE_EXISTS(DT_NODELABEL(sonycxd5605))
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "i2c read " I2C_1 " 24 10")) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "i2c read " I2C_1 " 24 10")) != 0) {
 		rc |= ret;
 		printf("i2c read " I2C_1 " 24 10 - Sony cxd5605 GNSS - shell command failed %d \n", ret);
 	} else {
 		printf("i2c read " I2C_1 " 24 10 - Sony cxd5605 GNSS - shell command was successful\n");
 	}
 #endif
+
 #if DT_NODE_EXISTS(DT_NODELABEL(tsl2540))
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "sensor get " TSL2540)) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "sensor get " TSL2540)) != 0) {
 		rc |= ret;
 		printf("sensor get " TSL2540 " - tsl25403 ambient light sensor - shell command failed %d \n", ret);
 	} else {
 		printf("sensor get " TSL2540 " - tsl25403 ambient light sensor - shell command was successful\n");
 	}
 #endif
+
 #if DT_NODE_EXISTS(DT_NODELABEL(murata_1sc))
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "tmo modem 1 imei")) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "tmo modem 1 imei")) != 0) {
 		rc |= ret;
 		printf("tmo modem 1 imei - murata 1sc- shell command failed %d \n", ret);
 	} else {
 		printf("tmo modem 1 imei - murata 1sc - shell command was successful\n");
 	}
 #endif
+
 #if DT_NODE_EXISTS(DT_NODELABEL(rs9116w))
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "tmo wifi status 2")) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "tmo wifi status 2")) != 0) {
 		rc |= ret;
 		printf("tmo wifi status 2 - rs9116w- shell command failed %d \n", ret);
 	} else {
@@ -111,48 +115,57 @@ int misc_test()
 		printf("tmo wifi scan 2 - rs9116w - shell command was successful\n");
 	}
 #endif
+
 #if DT_NODE_EXISTS(DT_NODELABEL(lis2dw12))
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "sensor get " LIS2DW12)) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "sensor get " LIS2DW12)) != 0) {
 		rc |= ret;
 		printf("sensor get " LIS2DW12 " - accelerometer - shell command failed %d \n", ret);
 	} else {
 		printf("sensor get " LIS2DW12 " - accelerometer - shell command was successful\n");
 	}
 #endif
+
 #if DT_NODE_EXISTS(DT_NODELABEL(lps22hh))
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "sensor get " LPS22HH)) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "sensor get " LPS22HH)) != 0) {
 		rc |= ret;
 		printf("sensor get " LPS22HH " - pressure sensor - shell command failed %d \n", ret);
 	} else {
 		printf("sensor get " LPS22HH " - pressure sensor - shell command was successful\n");
 	}
 #endif
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "fs write /tmo/access_id.txt 30 31 32 33 0a 0d")) != 0)
-	{
+
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "fs write /tmo/access_id.txt 30 31 32 33 0a 0d")) != 0) {
 		rc |= ret;
 		printf("fs write /tmo/access_id.txt 30 31 32 33 0a 0d - SPI nor flash - shell command failed %d \n", ret);
 	} else {
 		printf("fs write /tmo/access_id.txt 30 31 32 33 0a 0d - SPI nor flash - shell command was successful\n");
 	}
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "fs read /tmo/access_id.txt")) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "fs read /tmo/access_id.txt")) != 0) {
 		rc |= ret;
 		printf("fs read /tmo/access_id.txt - SPI nor flash - shell command failed %d \n", ret);
 	} else {
 		printf("fs read /tmo/access_id.txt - SPI nor flash - shell command was successful\n");
 	}
-	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "fs rm /tmo/access_id.txt")) != 0)
-	{
+	if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "fs rm /tmo/access_id.txt")) != 0) {
 		rc |= ret;
 		printf("fs fs rm /tmo/access_id.txt - SPI nor flash - shell command failed %d \n", ret);
 	} else {
 		printf("fs rm /tmo/access_id.txt - SPI nor flash - shell command was successful\n");
 	}
+
 	if (strcmp(CONFIG_BOARD, "tmo_dev_edge") == 0) {
-		if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "i2c scan " I2C_0)) != 0)
-		{
+		/* Check for presence of On Semi LC709204F fuel gauge
+		 * (battery must be present for this to pass)
+		 */
+		if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "i2c read " I2C_1 " 0xb 0x15 2")) != 0) {
+			rc |= ret;
+			printf("i2c read " I2C_1 "0xb 0x15 2 - LC709204F fuel gauge - shell command failed %d \n", ret);
+		} else {
+			printf("i2c read " I2C_1 "0xb 0x15 2 - LC709204F fuel gauge - shell command was successful\n");
+		}
+
+		/* Scan the secondary I2C bus (I2C_0) */
+		if ((ret = shell_execute_cmd(shell_backend_uart_get_ptr(), "i2c scan " I2C_0)) != 0) {
 			rc |= ret;
 			printf("i2c scan " I2C_0 " - shell command failed %d \n", ret);
 		} else {


### PR DESCRIPTION
This improves the 'tmo test mfg all' command. It prints bootloader slot and tmo_shell version details, prints the device list, and checks for the fuel gauge.