### PR TITLE
Fix pushbutton defect

### DIFF
--- a/samples/push_button_sample/Kconfig
+++ b/samples/push_button_sample/Kconfig
@@ -3,3 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 source "Kconfig.zephyr"
+
+mainmenu "Gecko Pushbutton"
+
+config PUSHBUTTON_ADDITIONAL_PULL_UP
+     bool "Pushbutton additional pull-up resistor"
+     default true
+     help
+        The additional conductance afforded by the Gecko GPIO pull-up resistor
+        reduces the RC time constant of the pushbutton debounce filter circuit,
+        making switch bounce more likely.

--- a/samples/push_button_sample/prj.conf
+++ b/samples/push_button_sample/prj.conf
@@ -9,3 +9,6 @@ CONFIG_GPIO=y
 
 # Stack sizes
 CONFIG_MAIN_STACK_SIZE=4096
+
+# Pull-up circuit - additional conductance
+CONFIG_PUSHBUTTON_ADDITIONAL_PULL_UP=n


### PR DESCRIPTION
1. Fix defect causing an endless loop
2. Remove a superfluous parameter passed to the GPIO configuration
    routine
3. Add a configuration option facilitating an option for an additional
    pull-up resistor