### PR TITLE
Fix build warnings with unused parameters

### DIFF
--- a/samples/tmo_shell/src/tmo_ble_demo.c
+++ b/samples/tmo_shell/src/tmo_ble_demo.c
@@ -879,9 +879,8 @@ static struct bt_conn_cb conn_callbacks = {
 	.connected = ble_connected,
 };
 
-static int tmo_ble_demo_init(const struct device *unused)
+static int tmo_ble_demo_init()
 {
-	ARG_UNUSED(unused);
 	int err;
 
 	err = bt_enable(NULL);

--- a/samples/tmo_shell/src/tmo_wifi.c
+++ b/samples/tmo_shell/src/tmo_wifi.c
@@ -485,10 +485,8 @@ int tmo_wifi_connect()
 	return ret;
 }
 
-static int tmo_wifi_shell_init(const struct device *unused)
+static int tmo_wifi_shell_init()
 {
-	ARG_UNUSED(unused);
-
 	context.shell = NULL;
 	context.all = 0U;
 	scan_result = 0U;


### PR DESCRIPTION
This fixes some build warnings related to unused parameters