### PR TITLE
Better error description for failed tmo modem

### DIFF
--- a/samples/tmo_shell/src/tmo_shell.c
+++ b/samples/tmo_shell/src/tmo_shell.c
@@ -178,7 +178,11 @@ int tcp_create_core(const struct shell *shell, size_t argc, char **argv, int fam
 	}
 	int sd = zsock_socket_ext(family, SOCK_STREAM, IPPROTO_TCP, iface);
 	if (sd == -1) {
-		shell_error(shell, "Socket creation failed, errno = %d", errno);
+		if (errno == ENOMEM) {
+			shell_error(shell, "No sockets available, errno = %d", errno);
+		} else {
+			shell_error(shell, "Socket creation failed, errno = %d", errno);
+		}
 		return 0;
 	}
 	shell_print(shell, "Created socket %d", sd);
@@ -224,7 +228,11 @@ int tcp_create_tls_core(const struct shell *shell, size_t argc, char **argv, int
 	}
 	int sd = zsock_socket_ext(family, SOCK_STREAM, IPPROTO_TLS_1_2, iface);
 	if (sd == -1) {
-		shell_error(shell, "Socket creation failed, errno = %d", errno);
+		if (errno == ENOMEM) {
+			shell_error(shell, "No sockets available, errno = %d", errno);
+		} else {
+			shell_error(shell, "Socket creation failed, errno = %d", errno);
+		}
 		return 0;
 	}
 
@@ -302,7 +310,11 @@ int udp_create_core(const struct shell *shell, size_t argc, char **argv, int fam
 	}
 	int sd = zsock_socket_ext(family, SOCK_DGRAM, IPPROTO_UDP, iface);
 	if (sd == -1) {
-		shell_error(shell, "Socket creation failed, errno = %d", errno);
+		if (errno == ENOMEM) {
+			shell_error(shell, "No sockets available, errno = %d", errno);
+		} else {
+			shell_error(shell, "Socket creation failed, errno = %d", errno);
+		}
 		return 0;
 	}
 	shell_print(shell, "Created socket %d", sd);
@@ -374,7 +386,11 @@ int udp_create_dtls_core(const struct shell *shell, size_t argc, char **argv, in
 	}
 	int sd = zsock_socket_ext(family, SOCK_DGRAM, IPPROTO_DTLS_1_2, iface);
 	if (sd == -1) {
-		shell_error(shell, "Socket creation failed, errno = %d", errno);
+		if (errno == ENOMEM) {
+			shell_error(shell, "No sockets available, errno = %d", errno);
+		} else {
+			shell_error(shell, "Socket creation failed, errno = %d", errno);
+		}
 		return 0;
 	}
 	shell_print(shell, "Created socket %d", sd);

--- a/samples/tmo_shell/src/tmo_sntp.c
+++ b/samples/tmo_shell/src/tmo_sntp.c
@@ -17,67 +17,59 @@ LOG_MODULE_REGISTER(sntp_client, LOG_LEVEL_DBG);
 #include <stdlib.h>
 #include <string.h>
 
-
 static int resolve_dns(const char *host, char *ip_str, int *ipVer)
 {
-    struct addrinfo hints;
-    struct addrinfo *res;
-    int errcode;
-    char addrstr[100];
-    void *ptr = NULL;
+	struct addrinfo hints;
+	struct addrinfo *res;
+	int errcode;
+	char addrstr[100];
+	void *ptr = NULL;
 
-    memset (&hints, 0, sizeof (hints));
-    hints.ai_family = PF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-    hints.ai_flags |= AI_CANONNAME;
+	memset(&hints, 0, sizeof(hints));
+	hints.ai_family = PF_UNSPEC;
+	hints.ai_socktype = SOCK_STREAM;
+	hints.ai_flags |= AI_CANONNAME;
 
-    errcode = getaddrinfo (host, NULL, &hints, &res);
-    if (errcode != 0)
-    {
-        printf ("[sntp] getaddrinfo\n");
-        return -1;
-    }
-    
+	errcode = getaddrinfo(host, NULL, &hints, &res);
+	if (errcode != 0) {
+		printf("[sntp] getaddrinfo\n");
+		return -1;
+	}
+
 	if (!res) {
 		printf("[sntp] result is null\n");
 		return -1;
 	}
 
-    printf ("[sntp] Host: %s\n", host);
-	inet_ntop (res->ai_family, res->ai_addr->data, addrstr, 100);
+	printf("[sntp] Host: %s\n", host);
+	inet_ntop(res->ai_family, res->ai_addr->data, addrstr, 100);
 
-	switch (res->ai_family)
-    {
-        case AF_INET:
-            ptr = &((struct sockaddr_in *) res->ai_addr)->sin_addr;
-			*ipVer = 4;
-        break;
-        case AF_INET6:
-            ptr = &((struct sockaddr_in6 *) res->ai_addr)->sin6_addr;
-			*ipVer = 6;
-        break;
-    }
+	switch (res->ai_family) {
+	case AF_INET:
+		ptr = &((struct sockaddr_in *)res->ai_addr)->sin_addr;
+		*ipVer = 4;
+		break;
+	case AF_INET6:
+		ptr = &((struct sockaddr_in6 *)res->ai_addr)->sin6_addr;
+		*ipVer = 6;
+		break;
+	}
 
-	inet_ntop (res->ai_family, ptr, addrstr, 100);
+	inet_ntop(res->ai_family, ptr, addrstr, 100);
 	memcpy(ip_str, addrstr, strlen(addrstr));
 	*ipVer = res->ai_family == PF_INET6 ? 6 : 4;
-	printf ("[sntp] IPv%d address: %s\n", *ipVer,ip_str);
+	printf("[sntp] IPv%d address: %s\n", *ipVer, ip_str);
 	freeaddrinfo(res);
-    return 0;
+	return 0;
 }
-
 
 static void date_print(const struct shell *shell, struct tm *tm)
 {
 	shell_print(shell,
-			"%d-%02u-%02u "
-			"%02u:%02u:%02u UTC",
-			tm->tm_year + 1900,
-			tm->tm_mon + 1,
-			tm->tm_mday,
-			tm->tm_hour,
-			tm->tm_min,
-			tm->tm_sec);
+		    "%d-%02u-%02u "
+		    "%02u:%02u:%02u UTC",
+		    tm->tm_year + 1900, tm->tm_mon + 1, tm->tm_mday, tm->tm_hour, tm->tm_min,
+		    tm->tm_sec);
 }
 
 static int time_date_set(const struct shell *shell, uint32_t epoch_sec)
@@ -87,14 +79,14 @@ static int time_date_set(const struct shell *shell, uint32_t epoch_sec)
 	tp.tv_sec = (uint32_t)epoch_sec;
 
 	gmtime_r(&tp.tv_sec, &tm);
-	date_print(shell,&tm);
+	date_print(shell, &tm);
 
 #if defined(CONFIG_COUNTER_GECKO_RTCC)
 	RTCC_CounterSet(tp.tv_sec);
 #endif
 
-	if( clock_settime( CLOCK_REALTIME, &tp) == -1 ) {
-		shell_error( shell, "system clock set failed" );
+	if (clock_settime(CLOCK_REALTIME, &tp) == -1) {
+		shell_error(shell, "system clock set failed");
 		return -EINVAL;
 	}
 	shell_print(shell, "successfully updated RTC");
@@ -104,10 +96,9 @@ static int time_date_set(const struct shell *shell, uint32_t epoch_sec)
 
 int isValidIpAddress(char *ipAddress)
 {
-    struct sockaddr_in sa;
-    return inet_pton(AF_INET, ipAddress, &(sa.sin_addr));
+	struct sockaddr_in sa;
+	return inet_pton(AF_INET, ipAddress, &(sa.sin_addr));
 }
-
 
 int tmo_update_time(const struct shell *shell, char *host, int iface_idx)
 {
@@ -120,14 +111,15 @@ int tmo_update_time(const struct shell *shell, char *host, int iface_idx)
 	int ipVer = 4;
 
 	// Create and zero out the packet. All 48 bytes worth.
-	ntp_packet packet = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-	memset( &packet, 0, sizeof( ntp_packet ) );
+	ntp_packet packet = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+	memset(&packet, 0, sizeof(ntp_packet));
 
-	// Set the first byte's bits to 00,011,011 for li = 0, vn = 3, and mode = 3. The rest will be left set to zero.
-	*( ( char * ) &packet + 0 ) = 0x1b; // Represents 27 in base 10 or 00011011 in base 2.
+	// Set the first byte's bits to 00,011,011 for li = 0, vn = 3, and mode = 3. The rest will
+	// be left set to zero.
+	*((char *)&packet + 0) = 0x1b; // Represents 27 in base 10 or 00011011 in base 2.
 
 	struct net_if *iface = net_if_get_by_index(iface_idx);
-	
+
 	if (tmo_offload_init(iface_idx)) {
 		return -1;
 	}
@@ -139,23 +131,26 @@ int tmo_update_time(const struct shell *shell, char *host, int iface_idx)
 
 	int sd = zsock_socket_ext(AF_INET, SOCK_DGRAM, IPPROTO_UDP, iface);
 	if (sd == -1) {
-		shell_error(shell, "Socket creation failed, errno = %d", errno);
+		if (errno == ENOMEM) {
+			shell_error(shell, "No sockets available, errno = %d", errno);
+		} else {
+			shell_error(shell, "Socket creation failed, errno = %d", errno);
+		}
 		return 0;
 	}
 
 	memset(ip_addr, 0, sizeof(char) * 100);
-    if (isValidIpAddress(host)) {
+	if (isValidIpAddress(host)) {
 #ifdef DEBUG
-        shell_print(shell, "ip");
+		shell_print(shell, "ip");
 #endif
-        strncpy(ip_addr,host, strlen(host));
-    }
-    else {
+		strncpy(ip_addr, host, strlen(host));
+	} else {
 #ifdef DEBUG
-        shell_print(shell, "dns");
+		shell_print(shell, "dns");
 #endif
 		resolve_dns(host, ip_addr, &ipVer);
-    }
+	}
 
 	struct sockaddr_in sin;
 	sin.sin_family = AF_INET;
@@ -169,7 +164,7 @@ int tmo_update_time(const struct shell *shell, char *host, int iface_idx)
 		shell_error(shell, "zsock_connect errno");
 	}
 
-	int stat = zsock_send(sd, ( char* ) &packet, sizeof( ntp_packet ), 0);
+	int stat = zsock_send(sd, (char *)&packet, sizeof(ntp_packet), 0);
 	if (stat == -1) {
 		shell_error(shell, "Send failed, errno = %d", errno);
 		zsock_close(sd);
@@ -177,12 +172,13 @@ int tmo_update_time(const struct shell *shell, char *host, int iface_idx)
 	}
 	k_msleep(2000);
 
-	int recvsize = sizeof( ntp_packet );
+	int recvsize = sizeof(ntp_packet);
 
-	memset( ( char* ) &packet, 0, sizeof( ntp_packet ));
+	memset((char *)&packet, 0, sizeof(ntp_packet));
 	int total = 0;
 	while (total < recvsize || recvsize == 0) {
-		stat = zsock_recv(sd,  (( char* ) &packet) + total, recvsize - total, ZSOCK_MSG_DONTWAIT);
+		stat = zsock_recv(sd, ((char *)&packet) + total, recvsize - total,
+				  ZSOCK_MSG_DONTWAIT);
 		if (stat == -1) {
 			shell_error(shell, "recv failed, errno = %d", errno);
 			zsock_close(sd);
@@ -196,10 +192,10 @@ int tmo_update_time(const struct shell *shell, char *host, int iface_idx)
 		return total;
 	}
 
-	packet.txTm_s = ntohl( packet.txTm_s ); // Time-stamp seconds.
-	packet.txTm_f = ntohl( packet.txTm_f ); // Time-stamp fraction of a second.
+	packet.txTm_s = ntohl(packet.txTm_s); // Time-stamp seconds.
+	packet.txTm_f = ntohl(packet.txTm_f); // Time-stamp fraction of a second.
 
-	time_t txTm = ( time_t ) ( packet.txTm_s - NTP_TIMESTAMP_DELTA );
+	time_t txTm = (time_t)(packet.txTm_s - NTP_TIMESTAMP_DELTA);
 #ifdef DEBUG
 	shell_print(shell, "epoch %lld", txTm);
 #endif


### PR DESCRIPTION
Better error descrioption for failed `tmo modem` command that results in `errno = 12`, meaning no sockets available.