### PR TITLE
Correct socket num description in error string

### DIFF
--- a/samples/tmo_shell/src/tmo_shell.c
+++ b/samples/tmo_shell/src/tmo_shell.c
@@ -556,7 +556,13 @@ int sock_connect(const struct shell *shell, size_t argc, char **argv)
 	int ret;
 	char *host;
 	struct sockaddr target;
+	errno = 0;
 	int sd = strtol(argv[1], NULL, 10);
+	if (errno != 0) {
+		shell_error(shell, "Socket %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	char *port_st = argv[3];
 	int sock_idx;
 	for (sock_idx = 0; sock_idx < MAX_SOCK_REC; sock_idx++) {
@@ -680,7 +686,13 @@ int sock_bind(const struct shell *shell, size_t argc, char **argv)
 		shell_help(shell);
 		return -EINVAL;
 	}
+	errno = 0;
 	int sd = strtol(argv[1], NULL, 10);
+	if (errno != 0) {
+		shell_error(shell, "Socket %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	int sock_idx;
 	for (sock_idx = 0; sock_idx < MAX_SOCK_REC; sock_idx++) {
 		if (socks[sock_idx].sd == sd && socks[sock_idx].flags & BIT(sock_open)) {
@@ -713,7 +725,13 @@ int sock_send(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
+	errno = 0;
 	int sd = strtol(argv[1], NULL, 10);
+	if (errno != 0) {
+		shell_error(shell, "Socket %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	int sock_idx;
 	for (sock_idx = 0; sock_idx < MAX_SOCK_REC; sock_idx++) {
 		if (socks[sock_idx].sd == sd && socks[sock_idx].flags & BIT(sock_open)) {
@@ -745,7 +763,13 @@ int sock_sendto(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
+	errno = 0;
 	int sd = strtol(argv[1], NULL, 10);
+	if (errno != 0) {
+		shell_error(shell, "Socket %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	int sock_idx;
 	for (sock_idx = 0; sock_idx < MAX_SOCK_REC; sock_idx++) {
 		if (socks[sock_idx].sd == sd && socks[sock_idx].flags & BIT(sock_open)) {
@@ -834,7 +858,13 @@ int sock_sendb(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
+	errno = 0;
 	int sd = strtol(argv[1], NULL, 10);
+	if (errno != 0) {
+		shell_error(shell, "Socket %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	int sock_idx;
 	for (sock_idx = 0; sock_idx < MAX_SOCK_REC; sock_idx++) {
 		if (socks[sock_idx].sd == sd && socks[sock_idx].flags & BIT(sock_open)) {
@@ -929,7 +959,13 @@ int sock_recvb(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
+	errno = 0;
 	int sd = strtol(argv[1], NULL, 10);
+	if (errno != 0) {
+		shell_error(shell, "Socket %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	int sock_idx;
 	for (sock_idx = 0; sock_idx < MAX_SOCK_REC; sock_idx++) {
 		if (socks[sock_idx].sd == sd && socks[sock_idx].flags & BIT(sock_open)) {
@@ -984,6 +1020,11 @@ int sock_rcv(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 	int sd = (int)strtol(argv[1], NULL, 10);
+	if (errno != 0) {
+		shell_error(shell, "Socket %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	int sock_idx;
 	for (sock_idx = 0; sock_idx < MAX_SOCK_REC; sock_idx++) {
 		if (socks[sock_idx].sd == sd && socks[sock_idx].flags & BIT(sock_open)) {
@@ -1029,6 +1070,11 @@ int sock_rcvfrom(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 	int sd = (int)strtol(argv[1], NULL, 10);
+	if (errno != 0) {
+		shell_error(shell, "Socket %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	int sock_idx;
 	for (sock_idx = 0; sock_idx < MAX_SOCK_REC; sock_idx++) {
 		if (socks[sock_idx].sd == sd && socks[sock_idx].flags & BIT(sock_open)) {
@@ -1083,7 +1129,13 @@ int sock_close(const struct shell *shell, size_t argc, char **argv)
 		shell_help(shell);
 		return -EINVAL;
 	}
+	errno = 0;
 	int sd = strtol(argv[1], NULL, 10);
+	if (errno != 0) {
+		shell_error(shell, "Socket %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	int sock_idx;
 	for (sock_idx = 0; sock_idx < MAX_SOCK_REC; sock_idx++) {
 		if (socks[sock_idx].sd == sd && socks[sock_idx].flags & BIT(sock_open)) {
@@ -1120,7 +1172,13 @@ int sock_sendsms(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
+	errno = 0;
 	int sd = strtol(argv[1], NULL, 10);
+	if (errno != 0) {
+		shell_error(shell, "Socket %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	int sock_idx;
 	for (sock_idx = 0; sock_idx < MAX_SOCK_REC; sock_idx++) {
 		if (socks[sock_idx].sd == sd && socks[sock_idx].flags & BIT(sock_open)) {
@@ -1152,9 +1210,19 @@ int sock_recvsms(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
+	errno = 0;
 	int sd = strtol(argv[1], NULL, 10);
-
+	if (errno != 0) {
+		shell_error(shell, "Socket %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	int wait = strtol(argv[2], NULL, 10);
+	if (errno != 0 && errno != ERANGE) {
+		shell_error(shell, "Timeout %s is invalid, errno = %d; %s", argv[1], errno,
+			    strerror(errno));
+		return errno;
+	}
 	int sock_idx;
 	for (sock_idx = 0; sock_idx < MAX_SOCK_REC; sock_idx++) {
 		if (socks[sock_idx].sd == sd && socks[sock_idx].flags & BIT(sock_open)) {


### PR DESCRIPTION
Previous to this commit, 
If the user performs an action on a non-existent socket in excess of max unsigned integer size it will return the value of 2147483647 incorrectly.

After this commit, the passed in socket num will be correctly displayed in the error message. 
As well as, added a check to determine if passed socket num is not an integer and returns the set errno appropriately.