### PR TITLE
CFSPDK-1274: Added a wrapper to individually disable devices, then enter system suspend

### DIFF
--- a/samples/tmo_shell/src/tmo_pm_sys.c
+++ b/samples/tmo_shell/src/tmo_pm_sys.c
@@ -16,83 +16,92 @@
 #include <zephyr/pm/device.h>
 #endif
 
-int cmd_pmsysactive(const struct shell *shell, int argc, char** argv)
+const struct device *tmo_dev_list[] = {DEVICE_DT_GET(DT_NODELABEL(rs9116w)),
+				       DEVICE_DT_GET(DT_NODELABEL(sonycxd5605)),
+				       DEVICE_DT_GET(DT_NODELABEL(murata_1sc))};
+
+#if CONFIG_PM_DEVICE
+static void tmo_pm_sys_lp_wrapper(bool turn_off)
+{
+	const struct device *dev = NULL;
+	for (int i = 0; i < sizeof(tmo_dev_list) / sizeof(tmo_dev_list[0]); i++) {
+		dev = tmo_dev_list[i];
+		pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
+		if (turn_off && dev != DEVICE_DT_GET(DT_NODELABEL(murata_1sc))) {
+			pm_device_action_run(dev, PM_DEVICE_ACTION_TURN_OFF);
+		}
+	}
+	dev = PWMLEDS;
+	led_off(dev, 0);
+	led_off(dev, 1);
+	led_off(dev, 2);
+	led_off(dev, 3);
+	dev = device_get_binding("gnss_pwr");
+	pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
+}
+#endif
+
+int cmd_pmsysactive(const struct shell *shell, int argc, char **argv)
 {
 	shell_print(shell, "Entering active state...");
 	pm_state_force(0u, &(struct pm_state_info){PM_STATE_ACTIVE, 0, 0});
 	return 0;
 }
 
-int cmd_pmsysidle(const struct shell *shell, int argc, char** argv)
+int cmd_pmsysidle(const struct shell *shell, int argc, char **argv)
 {
 	shell_print(shell, "Entering runtime-idle state...");
 	pm_state_force(0u, &(struct pm_state_info){PM_STATE_RUNTIME_IDLE, 0, 0});
 	return 0;
 }
 
-int cmd_pmsyssuspend(const struct shell *shell, int argc, char** argv)
+int cmd_pmsyssuspend(const struct shell *shell, int argc, char **argv)
 {
+#if CONFIG_PM_DEVICE
+	tmo_pm_sys_lp_wrapper(false);
+#endif
 	shell_print(shell, "Entering suspend-to-idle state...");
 	pm_state_force(0u, &(struct pm_state_info){PM_STATE_SUSPEND_TO_IDLE, 0, 0});
 	return 0;
 }
 
-int cmd_pmsysstandby(const struct shell *shell, int argc, char** argv)
+int cmd_pmsysstandby(const struct shell *shell, int argc, char **argv)
 {
+#if CONFIG_PM_DEVICE
+	tmo_pm_sys_lp_wrapper(false);
+#endif
 	shell_print(shell, "Entering standby state...");
 	pm_state_force(0u, &(struct pm_state_info){PM_STATE_STANDBY, 0, 0});
 	return 0;
 }
 
-int cmd_pmsysoff(const struct shell *shell, int argc, char** argv)
+int cmd_pmsysoff(const struct shell *shell, int argc, char **argv)
 {
-	#if CONFIG_PM_DEVICE
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(rs9116w));
-	pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
-	pm_device_action_run(dev, PM_DEVICE_ACTION_TURN_OFF);
-	dev = DEVICE_DT_GET(DT_NODELABEL(sonycxd5605));
-	pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
-	pm_device_action_run(dev, PM_DEVICE_ACTION_TURN_OFF);
-	dev = DEVICE_DT_GET(DT_NODELABEL(murata_1sc));
-	pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
-	dev = PWMLEDS;
-	led_off(dev, 0);
-	led_off(dev, 1);
-	led_off(dev, 2);
-	led_off(dev, 3);
-	#endif
-	shell_print(shell, "Shutting down. Use the reset or user button to bring the board back alive");
+#if CONFIG_PM_DEVICE
+	tmo_pm_sys_lp_wrapper(true);
+#endif
+	shell_print(shell,
+		    "Shutting down. Use the reset or user button to bring the board back alive");
 	GPIO_IntDisable(0xFFFF);
 	GPIO_IntClear(0xFFFFFFFF);
 	GPIO_PinModeSet(gpioPortB, 13, gpioModeInputPullFilter, 1);
 	GPIO_EM4EnablePinWakeup(BIT(9) << _GPIO_EM4WUEN_EM4WUEN_SHIFT, 0);
 	CRYOTIMER_EM4WakeupEnable(false);
-	pm_state_force(0u, &(struct pm_state_info){PM_STATE_SOFT_OFF, 1, 0});    
+	pm_state_force(0u, &(struct pm_state_info){PM_STATE_SOFT_OFF, 1, 0});
 	return 0;
 }
-int cmd_pmsysfulloff(const struct shell *shell, int argc, char** argv)
+int cmd_pmsysfulloff(const struct shell *shell, int argc, char **argv)
 {
-	#if CONFIG_PM_DEVICE
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(rs9116w));
-	pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
-	pm_device_action_run(dev, PM_DEVICE_ACTION_TURN_OFF);
-	dev = DEVICE_DT_GET(DT_NODELABEL(sonycxd5605));
-	pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
-	pm_device_action_run(dev, PM_DEVICE_ACTION_TURN_OFF);
-	dev = DEVICE_DT_GET(DT_NODELABEL(murata_1sc));
-	pm_device_action_run(dev, PM_DEVICE_ACTION_SUSPEND);
-	dev = PWMLEDS;
-	led_off(dev, 0);
-	led_off(dev, 1);
-	led_off(dev, 2);
-	led_off(dev, 3);
-	#endif
+#if CONFIG_PM_DEVICE
+	tmo_pm_sys_lp_wrapper(true);
+#endif
 	shell_warn(shell, "Warning RTCC will be lost");
-	shell_print(shell, "Shutting down. Use the reset or user button to bring the board back alive");
+	shell_print(shell,
+		    "Shutting down. Use the reset or user button to bring the board back alive");
 	GPIO_IntDisable(0xFFFF);
 	GPIO_IntClear(0xFFFFFFFF);
 	GPIO_PinModeSet(gpioPortB, 13, gpioModeInputPullFilter, 1);
 	GPIO_EM4EnablePinWakeup(BIT(9) << _GPIO_EM4WUEN_EM4WUEN_SHIFT, 0);
-	pm_state_force(0u, &(struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});    
+	pm_state_force(0u, &(struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
 	return 0;
 }


### PR DESCRIPTION
Before this commit,
When issuing the `tmo sys_pm suspend` or the `tmo sys_pm standby`, the system becomes completely unresponsive due to the murata and wifi driver's expecting an interruptible context during issuing their corresponding device specific low power commands to the chip, however the system is in an non-blockable state before entering the Zephyr's sys_pm `pm_system_suspend` function. 

After this commit, 
We implement a workaround that is a wrapper function which individually suspends the wifi, modem, gnss, gnss_pwr, LEDs devices and then make the rest of the system and remaining devices go to sleep.
