### PR TITLE
Make tmo_shell ADC activity defer to external.

### DIFF
--- a/samples/tmo_shell/src/tmo_adc.h
+++ b/samples/tmo_shell/src/tmo_adc.h
@@ -10,6 +10,5 @@
 int read_battery_voltage(void);
 int read_hwid(void);
 bool millivolts_to_percent(uint32_t millivolts, uint8_t *bv);
-void initADC();
 
 #endif

--- a/samples/tmo_shell/src/tmo_shell.c
+++ b/samples/tmo_shell/src/tmo_shell.c
@@ -3049,7 +3049,6 @@ void tmo_shell_main(void)
 	mountfs();
 
 	cxd5605_init();
-	initADC();
 #ifdef CONFIG_WIFI
 	tmo_wifi_connect();
 #endif


### PR DESCRIPTION
Presumably, defers to the APIs in tmo_devices.